### PR TITLE
Clarified how authenticate works

### DIFF
--- a/developer-ref-user-authentication.md
+++ b/developer-ref-user-authentication.md
@@ -118,8 +118,12 @@ $adapter = new Hybridauth\Provider\Google($config);
 /**
 * 3. Sign in a user with Google
 *
-* Hybridauth will attempt to negotiate with the Google api and authenticate the user. If for whatever reason the process fails,
-* Hybridauth will then throw an exception.
+* Hybridauth will attempt to negotiate with the Google api and authenticate the user.
+* This call will basically do one of 3 things...
+* 1) Redirect (with exit) away to show an authentication screen for a provider (e.g. Facebook's OAuth confirmation page)
+* 2) Finalize an incoming authentication and store access data in a session
+* 3) Confirm a session exists and do nothing
+* If for whatever reason the process fails, Hybridauth will then throw an exception.
 *
 * Note that if the user is already authenticated, then any subsequent call to this method will be ignored.
 */

--- a/introduction.md
+++ b/introduction.md
@@ -97,6 +97,10 @@ try{
     //simply replace 'Twitter' with 'Google' or 'Facebook'.
 
     //Attempt to authenticate users with a provider by name
+    //This call will basically do one of 3 things...
+    //1) Redirect away (with exit) to show an authentication screen for a provider (e.g. Facebook's OAuth confirmation page)
+    //2) Finalize an incoming authentication and store access data in a session
+    //3) Confirm a session exists and do nothing
     $adapter = $hybridauth->authenticate('Twitter'); 
 
     //Returns a boolean of whether the user is connected with Twitter


### PR DESCRIPTION
I think the 'authenticate' call needs to be documented clearly, and incidentally how sessions are used.
Right now it requires faith in it working as documented and as per the examples, but a dev doesn't understand it unless they read the code.